### PR TITLE
#22, set dev to cd, other branches to deploy on pull

### DIFF
--- a/.github/workflows/deploypulledbranch.yml
+++ b/.github/workflows/deploypulledbranch.yml
@@ -1,11 +1,12 @@
-name: Deploy Development Site
+name: Build out branch environment for testing before a merge is completed
 
-# This will always keep the development site up to date for hotfixes.
 on:
-  push:
-    branches: 
-    - "dev"
-
+  pull_request:
+    branches:
+    - "*"
+    - "!master"
+    - "!dev"
+    
 jobs:
   build-site:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#22  broke out separate pipelines for Dev, every other branch. Dev will be deployed continuously, feature branches deployed on pull request for review. 